### PR TITLE
Fix issue for large queries

### DIFF
--- a/catools/soap/soap.py
+++ b/catools/soap/soap.py
@@ -172,6 +172,19 @@ class SoapAPI(object):
         returnAttributes = returnAttributes if returnAttributes else []
         return self.doSelect(objType, searchCriteria, maxRows, attributes=returnAttributes).to_dict()
 
+    def searchObjects_250(self, objType, searchCriteria, returnAttributes=None):
+        returnAttributes = returnAttributes if returnAttributes else []
+        query=self.cl.service.doQuery(self.sid, objType, searchCriteria)
+        return_obj=[]
+        for x in range(0,query.listLength+1,250):
+               max=x+249
+               if (max > query.listLength-1):
+                    max=query.listLength-1
+               if (x < query.listLength):
+                    return_obj=return_obj+self.getListValues(query.listHandle,x,max,returnAttributes).to_dict()
+        self.freeListHandles(query.listHandle)
+        return return_obj
+
     def updateObject(self, obj_handle, attribute_changes, return_attributes=None):
         attribute_changes = self.createArrayOfString(attribute_changes)
         return_attributes = self.createArrayOfString(return_attributes)

--- a/catools/soap/soap.py
+++ b/catools/soap/soap.py
@@ -168,22 +168,25 @@ class SoapAPI(object):
     def __getattr__(self, service_name):
         return SoapService(self._session, service_name)
 
-    def searchObjects(self, objType, searchCriteria, maxRows=-1, returnAttributes=None):
-        returnAttributes = returnAttributes if returnAttributes else []
-        return self.doSelect(objType, searchCriteria, maxRows, attributes=returnAttributes).to_dict()
+    #def searchObjects(self, objType, searchCriteria, maxRows=-1, returnAttributes=None):
+    #    returnAttributes = returnAttributes if returnAttributes else []
+    #    return self.doSelect(objType, searchCriteria, maxRows, attributes=returnAttributes).to_dict()
 
-    def searchObjects_250(self, objType, searchCriteria, returnAttributes=None):
+    def searchObjects(self, objType, searchCriteria, maxRows=-1,returnAttributes=None):
         returnAttributes = returnAttributes if returnAttributes else []
-        query=self.cl.service.doQuery(self.sid, objType, searchCriteria)
-        return_obj=[]
-        for x in range(0,query.listLength+1,250):
-               max=x+249
-               if (max > query.listLength-1):
-                    max=query.listLength-1
-               if (x < query.listLength):
-                    return_obj=return_obj+self.getListValues(query.listHandle,x,max,returnAttributes).to_dict()
-        self.freeListHandles(query.listHandle)
-        return return_obj
+        if (maxRows > 250):
+            return_obj = []
+            query = self.cl.service.doQuery(self.sid, objType, searchCriteria)
+            for x in range(0,query.listLength+1,250):
+                   max = x+249
+                   if (max > query.listLength-1):
+                        max = query.listLength-1
+                   if (x < query.listLength):
+                        return_obj = return_obj+self.getListValues(query.listHandle,x,max,returnAttributes).to_dict()
+            self.freeListHandles(query.listHandle)
+            return return_obj
+        else:
+            return self.doSelect(objType, searchCriteria, maxRows, attributes=returnAttributes).to_dict()
 
     def updateObject(self, obj_handle, attribute_changes, return_attributes=None):
         attribute_changes = self.createArrayOfString(attribute_changes)


### PR DESCRIPTION
Per #https://techdocs.broadcom.com/us/en/ca-enterprise-software/business-management/ca-service-management/17-1/troubleshooting/troubleshooting-ca-service-desk-manager/how-to-extend-the-ca-sdm-soap-web-services-method-doquery-limitation-of-250-rows.html
so current searchobject function will only return 250 rows. Added secondary searchobject_250 to iterate through results to generate complete results.